### PR TITLE
Fix problem with immutability

### DIFF
--- a/src/app/reducers/tutorial.reducer.ts
+++ b/src/app/reducers/tutorial.reducer.ts
@@ -3,19 +3,19 @@ import { Tutorial } from './../models/tutorial.model'
 import * as TutorialActions from './../actions/tutorial.actions'
 
 const initialState: Tutorial = {
-    name: 'Initial Tutorial',
-    url: 'http://google.com'
+	name: 'Initial Tutorial',
+	url: 'http://google.com'
 }
 
 export function reducer(state: Tutorial[] = [initialState], action: TutorialActions.Actions) {
-    switch(action.type) {
-        case TutorialActions.ADD_TUTORIAL:
-            return [...state, action.payload];
+	switch (action.type) {
+		case TutorialActions.ADD_TUTORIAL:
+			return [...state, action.payload];
 
-        case TutorialActions.REMOVE_TUTORIAL:
-            state.splice(action.payload, 1)
-            return state;
-        default:
-            return state;
-    }
+		case TutorialActions.REMOVE_TUTORIAL:
+			const index = action.payload;
+			return [...state.slice(0, index), ...state.slice(index + 1)];
+		default:
+			return state;
+	}
 }


### PR DESCRIPTION
The handler for REMOVE_TUTORIAL action is breaking the immutability concept, because  the splice method updates the original state reference instead of creating a new one.